### PR TITLE
Missing `annotation` command

### DIFF
--- a/timew/timewarrior.py
+++ b/timew/timewarrior.py
@@ -15,6 +15,15 @@ class TimeWarrior:
         self.bin = bin
         self.simulate = simulate
 
+    def annotate(self, id, annotation):
+        """Add annotation to an existing interval
+
+        Args:
+            id (int): The Timewarrior id
+            annotation (str): Annotation text to be set
+        """
+        return self.__execute("annotate", f"@{id}", f"{annotation}")
+
     def cancel(self):
         """If there is an open interval, it is abandoned."""
         return self.__execute("cancel")


### PR DESCRIPTION
I am regularly annotating my time intervals. Unfortunately the current library does not support annotation of time intervals yet. Therefore I simply added the corresponding command, which works well on my local machine.